### PR TITLE
fix: correct backend service targetPort to 9090

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -54,7 +54,7 @@ spec:
     app: backend
   ports:
   - port: 9090
-    targetPort: 9091
+    targetPort: 9090
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This PR corrects the backend service targetPort to 9090 to match the containerPort in the backend Deployment.
This fix resolves connectivity issues between frontend and backend services.

Signed-off-by: KubeAssist Bot <kubeassist@example.com>