### PR TITLE
fix: correct backend service targetPort to 9090 to fix no endpoints issue

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -54,7 +54,7 @@ spec:
     app: backend
   ports:
   - port: 9090
-    targetPort: 9091
+    targetPort: 9090
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This PR fixes an issue with the backend service targetPort which was set incorrectly to 9091. The container port is 9090, so the targetPort is updated to 9090 to allow proper pod endpoints and fix HTTP 500 errors from frontend due to no backend endpoints.