### PR TITLE
fix: update backend service targetPort to 9090 to resolve HTTP 500 errors

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -54,7 +54,7 @@ spec:
     app: backend
   ports:
   - port: 9090
-    targetPort: 9091
+    targetPort: 9090
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
The backend service targetPort was incorrectly set to 9091, but the backend pods listen on port 9090. This caused HTTP 500 errors in frontend requests to backend. This PR fixes the targetPort to 9090 to align service with pod port.