### PR TITLE
Fix backend service targetPort to match backend container port

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -54,7 +54,7 @@ spec:
     app: backend
   ports:
   - port: 9090
-    targetPort: 9091
+    targetPort: 9090
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This PR fixes the backend service by correcting the targetPort from 9091 to 9090 to match the backend container port, resolving the connection refused issues and HTTP 500 errors from the frontend.