### PR TITLE
fix: update backend service targetPort to 9090 to resolve connection issue

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -54,7 +54,7 @@ spec:
     app: backend
   ports:
   - port: 9090
-    targetPort: 9091
+    targetPort: 9090
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This PR fixes the backend service targetPort to match the backend containerPort at 9090. This corrects the connection refused errors seen when frontend calls the backend service.

Steps done:
- Created branch fix-live-demo-branch from main
- Updated backend service targetPort from 9091 to 9090 in application.yaml
- Committed and pushing changes

After this PR is merged, ArgoCD sync will deploy the fix to the cluster.