### PR TITLE
fix: Correct backend service targetPort to 9090 to match backend container port

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -54,7 +54,7 @@ spec:
     app: backend
   ports:
   - port: 9090
-    targetPort: 9091
+    targetPort: 9090
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This PR fixes the backend Service targetPort from 9091 to 9090 to match the backend pod container listening port. This resolves connection refused errors seen from the frontend when communicating with the backend.

Steps done:
1. Created branch fix/backend-service-targetport
2. Updated backend service targetPort in application.yaml

Please review and merge. After merge, ArgoCD will sync the changes to the cluster.

This fix follows the GitOps practice of externalizing changes and automating rollouts.