### PR TITLE
fix: Update backend service targetPort to 9090 to fix connection refused

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -54,7 +54,7 @@ spec:
     app: backend
   ports:
   - port: 9090
-    targetPort: 9091
+    targetPort: 9090
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This PR fixes the backend Service targetPort from 9091 to 9090 to match the backend pod container listening port. This resolves connection refused errors seen from the frontend when communicating with the backend.

Steps taken:
1. Created branch fix-live-demo-branch from main.
2. Updated backend Service targetPort in application.yaml to 9090.

Please review and merge. After merge, ArgoCD will sync the changes to the cluster automatically.