### PR TITLE
fix: Correct backend service targetPort to 9090 to match container port

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -54,7 +54,7 @@ spec:
     app: backend
   ports:
   - port: 9090
-    targetPort: 9091
+    targetPort: 9090
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This PR fixes the backend service targetPort from 9091 to 9090 to match the backend container port. This resolves the HTTP 500 errors seen when the frontend calls the backend due to connection refused errors.