### PR TITLE
fix: update frontend UPSTREAM_URIS to backend port 9091 to fix HTTP 500 errors

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -100,7 +100,7 @@ spec:
         - name: "MESSAGE"
           value: "Hello from Frontend Service!"
         - name: "UPSTREAM_URIS"
-          value: "http://backend:9090"
+          value: "http://backend:9091"
         - name: "HTTP_CLIENT_KEEP_ALIVES"
           value: "false"
 ---


### PR DESCRIPTION
This PR updates the frontend deployment environment variable UPSTREAM_URIS from "http://backend:9090" to "http://backend:9091" to match the backend service target port. This fixes the HTTP 500 errors when the frontend calls the backend service.

- Changed UPSTREAM_URIS in frontend container env to http://backend:9091
- Created branch fix-live-demo-branch from main

Please review and merge to deploy the fix via ArgoCD.