### PR TITLE
fix: update backend service targetPort to 9090 to match backend pod containerPort

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -54,7 +54,7 @@ spec:
     app: backend
   ports:
   - port: 9090
-    targetPort: 9091
+    targetPort: 9090
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This PR fixes the HTTP 500 errors by updating the backend service targetPort from 9091 to 9090 to match the backend pod containerPort.

- Updated backend service targetPort to 9090 in application.yaml
- Created branch fix-live-demo-branch from main

Please review and merge to deploy the fix via ArgoCD.